### PR TITLE
Airflow deferrable

### DIFF
--- a/airflow_provider_hightouch/example_dags/example_hightouch_trigger_sync.py
+++ b/airflow_provider_hightouch/example_dags/example_hightouch_trigger_sync.py
@@ -5,7 +5,7 @@ from airflow.operators.latest_only import LatestOnlyOperator
 from airflow.utils.dates import days_ago
 
 from airflow_provider_hightouch.operators.hightouch import HightouchTriggerSyncOperator
-from airflow_provider_hightouch.sensors.hightouch import HightouchMonitorSyncRunOperator
+from airflow_provider_hightouch.sensors.hightouch import HightouchSyncRunSensor
 
 args = {"owner": "airflow"}
 
@@ -29,7 +29,7 @@ with DAG(
         task_id="run_sync", sync_id=5, synchronous=True, error_on_warning=True
     )
 
-    sync_sensor = HightouchMonitorSyncRunOperator(
+    sync_sensor = HightouchSyncRunSensor(
         task_id="sync_sensor",
         sync_run_id="123456",
         sync_id="123")

--- a/airflow_provider_hightouch/operators/hightouch.py
+++ b/airflow_provider_hightouch/operators/hightouch.py
@@ -33,8 +33,6 @@ class HightouchTriggerSyncOperator(BaseOperator):
     :type synchronous: bool
     :param deferrable: Whether to defer the execution of the operator
     :type deferrable: bool
-    :param end_from_trigger: Whether to end the task from the trigger
-    :type end_from_trigger: bool
     :param error_on_warning: Should sync warnings be treated as errors or ignored?
     :type error_on_warning: bool
     :param wait_seconds: Time to wait in between subsequent polls to the API.
@@ -50,7 +48,7 @@ class HightouchTriggerSyncOperator(BaseOperator):
         self,
         sync_id: Optional[str] = None,
         sync_slug: Optional[str] = None,
-        workspace_id: Optional[str] = None,
+        workspace_id: Optional[str] = "{Workspace Id}",
         connection_id: str = "hightouch_default",
         api_version: str = "v3",
         synchronous: bool = True,

--- a/airflow_provider_hightouch/operators/hightouch.py
+++ b/airflow_provider_hightouch/operators/hightouch.py
@@ -25,6 +25,8 @@ class HightouchTriggerSyncOperator(BaseOperator):
     :param sync_id: ID of the sync to trigger
     :type sync_id: int
     :param sync_slug: Slug of the sync to trigger
+    :param workspace_id: Workspace Id to pass to Airflow logs to build URL
+    :type workspace_id: str
     :param connection_id: Name of the connection to use, defaults to hightouch_default
     :type connection_id: str
     :param api_version: Hightouch API version. Only v3 is supported.
@@ -33,6 +35,8 @@ class HightouchTriggerSyncOperator(BaseOperator):
     :type synchronous: bool
     :param deferrable: Whether to defer the execution of the operator
     :type deferrable: bool
+    :param end_from_trigger: Whether to end the task from the trigger
+    :type end_from_trigger: bool
     :param error_on_warning: Should sync warnings be treated as errors or ignored?
     :type error_on_warning: bool
     :param wait_seconds: Time to wait in between subsequent polls to the API.
@@ -48,7 +52,7 @@ class HightouchTriggerSyncOperator(BaseOperator):
         self,
         sync_id: Optional[str] = None,
         sync_slug: Optional[str] = None,
-        workspace_id: Optional[str] = "{Workspace Id}",
+        workspace_id: Optional[str] = "{Workspace Slug}",
         connection_id: str = "hightouch_default",
         api_version: str = "v3",
         synchronous: bool = True,
@@ -103,60 +107,40 @@ class HightouchTriggerSyncOperator(BaseOperator):
                 self.log.warning(hightouch_output)
 
         else:
+
+            self.log.info("Start async request to run a sync.")
+            request_id = hook.start_sync(self.sync_id, self.sync_slug)
+
             if self.deferrable:
-                return self.handle_deferrable_execution(hook)
+
+                if not self.sync_id:
+                    self.sync_id = hook.get_sync_from_slug(sync_slug=self.sync_slug)
+
+                self.sync_run_url = (
+                    f"https://app.hightouch.com/{self.workspace_id}/"
+                    f"syncs/{self.sync_id}/runs/{request_id}"
+                )
+
+                self.log.info(
+                    f"Started sync {self.sync_run_url} Deferring execution..."
+                )
+
+                self.defer(
+                    trigger=HightouchTrigger(
+                        sync_run_url=self.sync_run_url,
+                        sync_id=self.sync_id,
+                        sync_request_id=request_id,
+                        sync_slug=self.sync_slug,
+                        connection_id=self.hightouch_conn_id,
+                        timeout=self.timeout,
+                        end_from_trigger=True,
+                        poll_interval=self.wait_seconds,
+                    ),
+                    method_name=None,
+                )
             else:
-                self.log.info("Start async request to run a sync.")
-                request_id = hook.start_sync(self.sync_id, self.sync_slug)
                 sync = self.sync_id or self.sync_slug
                 self.log.info(
-                    "Successfully created request %s to start sync: %s",
-                    request_id,
-                    sync,
+                    f"Successfully created request {request_id} to start sync: {sync}"
                 )
                 return request_id
-
-    def handle_deferrable_execution(self, hook: HightouchHook) -> str:
-        """
-        Handle the deferrable execution logic for triggering a Hightouch sync.
-
-        The method defers execution until the sync completes, using a trigger to monitor the status.
-
-        :param hook: An instance of HightouchHook used to interact with the Hightouch API.
-        :type hook: HightouchHook
-
-        :raises AirflowException: If neither sync_id nor sync_slug is provided, or if both are provided.
-
-        :return: None
-        """
-        self.log.info("Using deferrable execution to trigger sync.")
-
-        if self.sync_slug:
-            self.log.info(
-                f"Triggering sync asynchronously using slug ID: {self.sync_slug}..."
-            )
-            sync_request_id = hook.start_sync(sync_slug=self.sync_slug)
-            self.sync_id = hook.get_sync_from_slug(sync_slug=self.sync_slug)
-        else:
-            self.log.info(
-                f"Triggering sync asynchronously using sync ID: {self.sync_id}..."
-            )
-            sync_request_id = hook.start_sync(sync_id=self.sync_id)
-
-        self.sync_run_url = f"https://app.hightouch.com/{self.workspace_id}/syncs/{self.sync_id}/runs/{sync_request_id}"
-
-        self.log.info(f"Started sync {self.sync_run_url} Deferring execution...")
-        self.defer(
-            trigger=HightouchTrigger(
-                sync_run_url=self.sync_run_url,
-                sync_id=self.sync_id,
-                sync_request_id=sync_request_id,
-                sync_slug=self.sync_slug,
-                connection_id=self.hightouch_conn_id,
-                timeout=self.timeout,
-                end_from_trigger=True,
-                poll_interval=self.wait_seconds,
-            ),
-            method_name=None,
-        )
-        return

--- a/airflow_provider_hightouch/operators/hightouch.py
+++ b/airflow_provider_hightouch/operators/hightouch.py
@@ -33,6 +33,8 @@ class HightouchTriggerSyncOperator(BaseOperator):
     :type synchronous: bool
     :param deferrable: Whether to defer the execution of the operator
     :type deferrable: bool
+    :param end_from_trigger: Whether to end the task from the trigger
+    :type end_from_trigger: bool
     :param error_on_warning: Should sync warnings be treated as errors or ignored?
     :type error_on_warning: bool
     :param wait_seconds: Time to wait in between subsequent polls to the API.
@@ -53,6 +55,7 @@ class HightouchTriggerSyncOperator(BaseOperator):
         api_version: str = "v3",
         synchronous: bool = True,
         deferrable: bool = False,
+        end_from_triggger: bool = True,
         error_on_warning: bool = False,
         wait_seconds: float = 3,
         timeout: int = 3600,
@@ -67,6 +70,7 @@ class HightouchTriggerSyncOperator(BaseOperator):
         self.error_on_warning = error_on_warning
         self.synchronous = synchronous
         self.deferrable = deferrable
+        self.end_from_trigger = end_from_triggger
         self.wait_seconds = wait_seconds
         self.timeout = timeout
 
@@ -129,7 +133,6 @@ class HightouchTriggerSyncOperator(BaseOperator):
 
         :return: None
         """
-
         self.log.info("Using deferrable execution to trigger sync.")
         # Validate that exactly one of sync_id or sync_slug is provided
         if (self.sync_id is None) == (self.sync_slug is None):
@@ -161,33 +164,8 @@ class HightouchTriggerSyncOperator(BaseOperator):
                 connection_id=self.hightouch_conn_id,
                 poll_interval=self.wait_seconds,
                 timeout=self.timeout,
+                end_from_trigger=self.end_from_trigger,
             ),
             method_name=None,
         )
         return
-
-    # def execute_complete(self, context: Context, event: dict):
-    #     """
-    #     Resumes execution after the trigger completes.
-
-    #     This method is called after the Hightouch sync completes. It processes the
-    #     event containing the sync status and raises exceptions if the sync fails or
-    #     times out.
-
-    #     Args:
-    #         context (Context): The context in which the operator is executed.
-    #         event (dict): The event containing the sync status.
-
-    #     Raises:
-    #         AirflowException: If the sync fails or times out.
-    #     """
-    #     status = event.get("status")
-    #     message = event.get("message")
-
-    #     if status == "success":
-    #         self.log.info(message)
-    #         return event.get("sync_id", None)
-    #     elif status in ["failed", "timeout"]:
-    #         raise AirflowException(message)
-    #     else:
-    #         raise AirflowException(message)

--- a/airflow_provider_hightouch/operators/hightouch.py
+++ b/airflow_provider_hightouch/operators/hightouch.py
@@ -3,9 +3,11 @@ from typing import Optional
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.context import Context
 
 from airflow_provider_hightouch.hooks.hightouch import HightouchHook
 from airflow_provider_hightouch.utils import parse_sync_run_details
+from airflow_provider_hightouch.triggers.hightouch import HightouchTrigger
 
 
 class HightouchLink(BaseOperatorLink):
@@ -20,10 +22,6 @@ class HightouchTriggerSyncOperator(BaseOperator):
     This operator triggers a run for a specified Sync in Hightouch via the
     Hightouch API.
 
-    .. seealso::
-        For more information on how to use this operator, take a look at the guide:
-        :ref:`https://hightouch.io/docs/integrations/airflow/`
-
     :param sync_id: ID of the sync to trigger
     :type sync_id: int
     :param sync_slug: Slug of the sync to trigger
@@ -33,6 +31,8 @@ class HightouchTriggerSyncOperator(BaseOperator):
     :type api_version: str
     :param synchronous: Whether to wait for the sync to complete before completing the task
     :type synchronous: bool
+    :param deferrable: Whether to defer the execution of the operator
+    :type deferrable: bool
     :param error_on_warning: Should sync warnings be treated as errors or ignored?
     :type error_on_warning: bool
     :param wait_seconds: Time to wait in between subsequent polls to the API.
@@ -48,9 +48,11 @@ class HightouchTriggerSyncOperator(BaseOperator):
         self,
         sync_id: Optional[str] = None,
         sync_slug: Optional[str] = None,
+        workspace_id: Optional[str] = None,
         connection_id: str = "hightouch_default",
         api_version: str = "v3",
         synchronous: bool = True,
+        deferrable: bool = False,
         error_on_warning: bool = False,
         wait_seconds: float = 3,
         timeout: int = 3600,
@@ -61,12 +63,14 @@ class HightouchTriggerSyncOperator(BaseOperator):
         self.api_version = api_version
         self.sync_id = sync_id
         self.sync_slug = sync_slug
+        self.workspace_id = workspace_id
         self.error_on_warning = error_on_warning
         self.synchronous = synchronous
+        self.deferrable = deferrable
         self.wait_seconds = wait_seconds
         self.timeout = timeout
 
-    def execute(self, context) -> str:
+    def execute(self, context: Context) -> str:
         """Start a Hightouch Sync Run"""
         hook = HightouchHook(
             hightouch_conn_id=self.hightouch_conn_id,
@@ -77,6 +81,9 @@ class HightouchTriggerSyncOperator(BaseOperator):
             raise AirflowException(
                 "One of sync_id or sync_slug must be provided to trigger a sync"
             )
+
+        if self.deferrable:
+            return self.handle_deferrable_execution(hook)
 
         if self.synchronous:
             self.log.info("Start synchronous request to run a sync.")
@@ -106,3 +113,81 @@ class HightouchTriggerSyncOperator(BaseOperator):
                 "Successfully created request %s to start sync: %s", request_id, sync
             )
             return request_id
+
+    def handle_deferrable_execution(self, hook: HightouchHook) -> str:
+        """
+        Handle the deferrable execution logic for triggering a Hightouch sync.
+
+        This method checks whether to trigger a Hightouch sync using either a sync ID or a sync slug.
+        It validates that exactly one of the two is provided and then initiates the sync asynchronously.
+        The method defers execution until the sync completes, using a trigger to monitor the status.
+
+        :param hook: An instance of HightouchHook used to interact with the Hightouch API.
+        :type hook: HightouchHook
+
+        :raises AirflowException: If neither sync_id nor sync_slug is provided, or if both are provided.
+
+        :return: None
+        """
+
+        self.log.info("Using deferrable execution to trigger sync.")
+        # Validate that exactly one of sync_id or sync_slug is provided
+        if (self.sync_id is None) == (self.sync_slug is None):
+            raise AirflowException(
+                "Exactly one of sync_id or sync_slug must be provided."
+            )
+
+        if self.sync_slug:
+            self.log.info(
+                f"Triggering sync asynchronously using slug ID: {self.sync_slug}..."
+            )
+            sync_request_id = hook.start_sync(sync_slug=self.sync_slug)
+            self.sync_id = hook.get_sync_from_slug(sync_slug=self.sync_slug)
+        else:
+            self.log.info(
+                f"Triggering sync asynchronously using sync ID: {self.sync_id}..."
+            )
+            sync_request_id = hook.start_sync(sync_id=self.sync_id)
+
+        self.log.info(
+            f"Successfully started sync {self.sync_id}. Deferring execution..."
+        )
+        self.defer(
+            trigger=HightouchTrigger(
+                workspace_id=self.workspace_id,
+                sync_id=self.sync_id,
+                sync_request_id=sync_request_id,
+                sync_slug=self.sync_slug,
+                connection_id=self.hightouch_conn_id,
+                poll_interval=self.wait_seconds,
+                timeout=self.timeout,
+            ),
+            method_name=None,
+        )
+        return
+
+    # def execute_complete(self, context: Context, event: dict):
+    #     """
+    #     Resumes execution after the trigger completes.
+
+    #     This method is called after the Hightouch sync completes. It processes the
+    #     event containing the sync status and raises exceptions if the sync fails or
+    #     times out.
+
+    #     Args:
+    #         context (Context): The context in which the operator is executed.
+    #         event (dict): The event containing the sync status.
+
+    #     Raises:
+    #         AirflowException: If the sync fails or times out.
+    #     """
+    #     status = event.get("status")
+    #     message = event.get("message")
+
+    #     if status == "success":
+    #         self.log.info(message)
+    #         return event.get("sync_id", None)
+    #     elif status in ["failed", "timeout"]:
+    #         raise AirflowException(message)
+    #     else:
+    #         raise AirflowException(message)

--- a/airflow_provider_hightouch/operators/hightouch.py
+++ b/airflow_provider_hightouch/operators/hightouch.py
@@ -33,8 +33,6 @@ class HightouchTriggerSyncOperator(BaseOperator):
     :type synchronous: bool
     :param deferrable: Whether to defer the execution of the operator
     :type deferrable: bool
-    :param end_from_trigger: Whether to end the task from the trigger
-    :type end_from_trigger: bool
     :param error_on_warning: Should sync warnings be treated as errors or ignored?
     :type error_on_warning: bool
     :param wait_seconds: Time to wait in between subsequent polls to the API.
@@ -55,7 +53,6 @@ class HightouchTriggerSyncOperator(BaseOperator):
         api_version: str = "v3",
         synchronous: bool = True,
         deferrable: bool = False,
-        end_from_triggger: bool = True,
         error_on_warning: bool = False,
         wait_seconds: float = 3,
         timeout: int = 3600,
@@ -70,7 +67,6 @@ class HightouchTriggerSyncOperator(BaseOperator):
         self.error_on_warning = error_on_warning
         self.synchronous = synchronous
         self.deferrable = deferrable
-        self.end_from_trigger = end_from_triggger
         self.wait_seconds = wait_seconds
         self.timeout = timeout
 
@@ -164,7 +160,6 @@ class HightouchTriggerSyncOperator(BaseOperator):
                 connection_id=self.hightouch_conn_id,
                 poll_interval=self.wait_seconds,
                 timeout=self.timeout,
-                end_from_trigger=self.end_from_trigger,
             ),
             method_name=None,
         )

--- a/airflow_provider_hightouch/operators/hightouch.py
+++ b/airflow_provider_hightouch/operators/hightouch.py
@@ -35,8 +35,6 @@ class HightouchTriggerSyncOperator(BaseOperator):
     :type synchronous: bool
     :param deferrable: Whether to defer the execution of the operator
     :type deferrable: bool
-    :param end_from_trigger: Whether to end the task from the trigger
-    :type end_from_trigger: bool
     :param error_on_warning: Should sync warnings be treated as errors or ignored?
     :type error_on_warning: bool
     :param wait_seconds: Time to wait in between subsequent polls to the API.

--- a/airflow_provider_hightouch/triggers/hightouch.py
+++ b/airflow_provider_hightouch/triggers/hightouch.py
@@ -1,0 +1,137 @@
+import asyncio
+from typing import Any, AsyncIterator, Dict, Optional, Tuple
+
+from airflow.triggers.base import (
+    BaseTrigger,
+    TriggerEvent,
+    TaskSuccessEvent,
+    TaskFailedEvent,
+)
+from airflow_provider_hightouch.hooks.hightouch import HightouchAsyncHook
+
+
+class HightouchTrigger(BaseTrigger):
+    """
+    Trigger to monitor a Hightouch sync run asynchronously.
+
+    This trigger checks the status of a Hightouch sync run at regular intervals
+    until it completes, fails, or times out. It uses the Hightouch API to retrieve
+    the sync status and yields events based on the sync's progress.
+
+    Args:
+        workspace_id (str): The Hightouch workspace_id.
+        sync_id (str): The ID of the Hightouch sync.
+        sync_request_id (str): The request ID of the sync run to monitor.
+        sync_slug (str): The slug of the Hightouch sync.
+        connection_id (str): The Airflow connection ID for Hightouch API access.
+        timeout (float): The maximum time (in seconds) to wait before timing out.
+        poll_interval (float): The time (in seconds) to wait between status checks.
+    """
+
+    def __init__(
+        self,
+        workspace_id: Optional[str],
+        sync_id: Optional[str],
+        sync_request_id: str,
+        sync_slug: Optional[str],
+        connection_id: str,
+        timeout: float,
+        poll_interval: float = 4.0,
+    ) -> None:
+        """
+        Initializes the HightouchTrigger with the provided parameters.
+
+        Args:
+            workspace_id (str): The Hightouch workspace_id.
+            sync_id (str): The ID of the Hightouch sync.
+            sync_request_id (str): The request ID of the sync run to monitor.
+            sync_slug (str): The slug of the Hightouch sync.
+            connection_id (str): The Airflow connection ID for Hightouch API access.
+            timeout (float): The maximum time (in seconds) to wait before timing out.
+            poll_interval (float): The time (in seconds) to wait between status checks.
+        """
+        super().__init__()
+        self.workspace_id = workspace_id
+        self.sync_id = sync_id
+        self.sync_request_id = sync_request_id
+        self.sync_slug = sync_slug
+        self.connection_id = connection_id
+        self.poll_interval = poll_interval
+        self.timeout = timeout
+        self.hook = HightouchAsyncHook(hightouch_conn_id=self.connection_id)
+
+    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+        """
+        Serialize the trigger state for storage.
+
+        Returns:
+            Tuple[str, Dict[str, Any]]: A tuple containing the fully qualified class name
+            and a dictionary of the trigger's parameters for state restoration.
+        """
+        return (
+            f"{self.__module__}.{self.__class__.__name__}",
+            {
+                "sync_id": self.sync_id,
+                "sync_request_id": self.sync_request_id,
+                "sync_slug": self.sync_slug,
+                "connection_id": self.connection_id,
+                "poll_interval": self.poll_interval,
+                "timeout": self.timeout,
+                "workspace_id": self.workspace_id,
+            },
+        )
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        """
+        Periodically checks the sync status until completion or timeout.
+
+        This method uses the Hightouch API to check the status of a sync run at
+        regular intervals defined by the poll_interval. It yields TriggerEvents
+        based on the current status of the sync.
+
+        Yields:
+            AsyncIterator[TriggerEvent]: Events indicating the status of the sync run,
+            which can be "success", "failed", "timeout", or the current status during polling.
+        """
+        start_time = asyncio.get_event_loop().time()
+        full_url = f"https://app.hightouch.com/{self.workspace_id}/syncs/{self.sync_id}/runs/{self.sync_request_id}"
+
+        while True:
+
+            try:
+                # Fetch the current sync status
+                response = await self.hook.get_sync_run_details(
+                    self.sync_id, self.sync_request_id
+                )
+
+                status = response[0].get("status")
+
+                # Handle different sync statuses
+                if status in ["success", "completed"]:
+                    f"{full_url} finished with status {status}!"
+                    yield TaskSuccessEvent()
+                    return
+
+                elif status in ["queued", "processing", "querying"]:
+                    self.log.info(
+                        f"Sync is {status}... Sleeping for {self.poll_interval} seconds."
+                    )
+                    await asyncio.sleep(self.poll_interval)
+
+                elif status in ["failed", "error"]:
+                    self.log.info(
+                        f"{full_url} finished with status {status}!\n"
+                        f"Sync Error: {response['error']}"
+                    )
+                    yield TaskFailedEvent()
+
+                # Check for timeout
+                if asyncio.get_event_loop().time() - start_time > self.timeout:
+                    self.log.info(
+                        f"{full_url} exceeded DAG timeout of {self.timeout} seconds."
+                    )
+                    yield TaskFailedEvent()
+
+            except Exception as e:
+                self.log.error("Error while checking sync status: %s", str(e))
+                yield TaskFailedEvent()

--- a/airflow_provider_hightouch/triggers/hightouch.py
+++ b/airflow_provider_hightouch/triggers/hightouch.py
@@ -124,7 +124,7 @@ class HightouchTrigger(BaseTrigger):
                 elif status in ["failed", "error"]:
                     self.log.info(
                         f"{self.sync_run_url} finished with status {status}!\n"
-                        f"Sync Error: {response['error']}"
+                        f"Sync Error: {response[0]['error']}"
                     )
                     yield TaskFailedEvent()
                     return

--- a/airflow_provider_hightouch/triggers/hightouch.py
+++ b/airflow_provider_hightouch/triggers/hightouch.py
@@ -135,6 +135,7 @@ class HightouchTrigger(BaseTrigger):
                         f"{self.sync_run_url} exceeded DAG timeout of {self.timeout} seconds."
                     )
                     yield TaskFailedEvent()
+                    return
 
             except Exception as e:
                 self.log.error("Error while checking sync status: %s", str(e))

--- a/airflow_provider_hightouch/triggers/hightouch.py
+++ b/airflow_provider_hightouch/triggers/hightouch.py
@@ -37,7 +37,6 @@ class HightouchTrigger(BaseTrigger):
         connection_id: str,
         timeout: float,
         poll_interval: float = 4.0,
-        end_from_trigger: bool = True,
     ) -> None:
         """
         Initializes the HightouchTrigger with the provided parameters.
@@ -59,7 +58,6 @@ class HightouchTrigger(BaseTrigger):
         self.connection_id = connection_id
         self.poll_interval = poll_interval
         self.timeout = timeout
-        self.end_from_trigger = end_from_trigger
         self.hook = HightouchAsyncHook(hightouch_conn_id=self.connection_id)
 
     def serialize(self) -> Tuple[str, Dict[str, Any]]:
@@ -80,7 +78,7 @@ class HightouchTrigger(BaseTrigger):
                 "poll_interval": self.poll_interval,
                 "timeout": self.timeout,
                 "workspace_id": self.workspace_id,
-                "end_from_trigger": self.end_from_trigger,
+                "end_from_trigger": True,
             },
         )
 

--- a/airflow_provider_hightouch/triggers/hightouch.py
+++ b/airflow_provider_hightouch/triggers/hightouch.py
@@ -37,6 +37,7 @@ class HightouchTrigger(BaseTrigger):
         connection_id: str,
         timeout: float,
         poll_interval: float = 4.0,
+        end_from_trigger: bool = True,
     ) -> None:
         """
         Initializes the HightouchTrigger with the provided parameters.
@@ -58,6 +59,7 @@ class HightouchTrigger(BaseTrigger):
         self.connection_id = connection_id
         self.poll_interval = poll_interval
         self.timeout = timeout
+        self.end_from_trigger = end_from_trigger
         self.hook = HightouchAsyncHook(hightouch_conn_id=self.connection_id)
 
     def serialize(self) -> Tuple[str, Dict[str, Any]]:
@@ -78,6 +80,7 @@ class HightouchTrigger(BaseTrigger):
                 "poll_interval": self.poll_interval,
                 "timeout": self.timeout,
                 "workspace_id": self.workspace_id,
+                "end_from_trigger": self.end_from_trigger,
             },
         )
 
@@ -108,9 +111,8 @@ class HightouchTrigger(BaseTrigger):
 
                 # Handle different sync statuses
                 if status in ["success", "completed"]:
-                    f"{full_url} finished with status {status}!"
+                    self.log.info(f"{full_url} finished with status {status}!")
                     yield TaskSuccessEvent()
-                    return
 
                 elif status in ["queued", "processing", "querying"]:
                     self.log.info(

--- a/airflow_provider_hightouch/triggers/hightouch.py
+++ b/airflow_provider_hightouch/triggers/hightouch.py
@@ -19,7 +19,7 @@ class HightouchTrigger(BaseTrigger):
     the sync status and yields events based on the sync's progress.
 
     Args:
-        workspace_id (str): The Hightouch workspace_id.
+        sync_run_url (str): Constructed sync_run_url.
         sync_id (str): The ID of the Hightouch sync.
         sync_request_id (str): The request ID of the sync run to monitor.
         sync_slug (str): The slug of the Hightouch sync.
@@ -30,34 +30,37 @@ class HightouchTrigger(BaseTrigger):
 
     def __init__(
         self,
-        workspace_id: Optional[str],
+        sync_run_url: Optional[str],
         sync_id: Optional[str],
         sync_request_id: str,
         sync_slug: Optional[str],
         connection_id: str,
         timeout: float,
+        end_from_trigger: bool = True,
         poll_interval: float = 4.0,
     ) -> None:
         """
         Initializes the HightouchTrigger with the provided parameters.
 
         Args:
-            workspace_id (str): The Hightouch workspace_id.
+            sync_run_url (str): Constructed sync_run_url.
             sync_id (str): The ID of the Hightouch sync.
             sync_request_id (str): The request ID of the sync run to monitor.
             sync_slug (str): The slug of the Hightouch sync.
             connection_id (str): The Airflow connection ID for Hightouch API access.
             timeout (float): The maximum time (in seconds) to wait before timing out.
+            end_from_trigger (bool): Allows for task to complete from the trigger. Default is true.
             poll_interval (float): The time (in seconds) to wait between status checks.
         """
         super().__init__()
-        self.workspace_id = workspace_id
+        self.sync_run_url = sync_run_url
         self.sync_id = sync_id
         self.sync_request_id = sync_request_id
         self.sync_slug = sync_slug
         self.connection_id = connection_id
         self.poll_interval = poll_interval
         self.timeout = timeout
+        self.end_from_trigger = end_from_trigger
         self.hook = HightouchAsyncHook(hightouch_conn_id=self.connection_id)
 
     def serialize(self) -> Tuple[str, Dict[str, Any]]:
@@ -71,14 +74,14 @@ class HightouchTrigger(BaseTrigger):
         return (
             f"{self.__module__}.{self.__class__.__name__}",
             {
+                "sync_run_url": self.sync_run_url,
                 "sync_id": self.sync_id,
                 "sync_request_id": self.sync_request_id,
                 "sync_slug": self.sync_slug,
                 "connection_id": self.connection_id,
-                "poll_interval": self.poll_interval,
                 "timeout": self.timeout,
-                "workspace_id": self.workspace_id,
-                "end_from_trigger": True,
+                "end_from_trigger": self.end_from_trigger,
+                "poll_interval": self.poll_interval,
             },
         )
 
@@ -95,7 +98,6 @@ class HightouchTrigger(BaseTrigger):
             which can be "success", "failed", "timeout", or the current status during polling.
         """
         start_time = asyncio.get_event_loop().time()
-        full_url = f"https://app.hightouch.com/{self.workspace_id}/syncs/{self.sync_id}/runs/{self.sync_request_id}"
 
         while True:
 
@@ -109,8 +111,9 @@ class HightouchTrigger(BaseTrigger):
 
                 # Handle different sync statuses
                 if status in ["success", "completed"]:
-                    self.log.info(f"{full_url} finished with status {status}!")
+                    self.log.info(f"{self.sync_run_url} finished with status {status}!")
                     yield TaskSuccessEvent()
+                    return
 
                 elif status in ["queued", "processing", "querying"]:
                     self.log.info(
@@ -120,18 +123,20 @@ class HightouchTrigger(BaseTrigger):
 
                 elif status in ["failed", "error"]:
                     self.log.info(
-                        f"{full_url} finished with status {status}!\n"
+                        f"{self.sync_run_url} finished with status {status}!\n"
                         f"Sync Error: {response['error']}"
                     )
                     yield TaskFailedEvent()
+                    return
 
                 # Check for timeout
                 if asyncio.get_event_loop().time() - start_time > self.timeout:
                     self.log.info(
-                        f"{full_url} exceeded DAG timeout of {self.timeout} seconds."
+                        f"{self.sync_run_url} exceeded DAG timeout of {self.timeout} seconds."
                     )
                     yield TaskFailedEvent()
 
             except Exception as e:
                 self.log.error("Error while checking sync status: %s", str(e))
                 yield TaskFailedEvent()
+                return


### PR DESCRIPTION
This PR refactors the existing Hightouch operator/hook to run syncs in deferrable mode. We are introducing a trigerrer which will poke for certain events related to sync completion.