### PR TITLE
Adds error_on_warning flag to trigger

### DIFF
--- a/airflow_provider_hightouch/operators/hightouch.py
+++ b/airflow_provider_hightouch/operators/hightouch.py
@@ -133,6 +133,7 @@ class HightouchTriggerSyncOperator(BaseOperator):
                         timeout=self.timeout,
                         end_from_trigger=True,
                         poll_interval=self.wait_seconds,
+                        error_on_warning=self.error_on_warning,
                     ),
                     method_name=None,
                 )


### PR DESCRIPTION
This PR makes use of the existing operator parameter error_on_warning and passes it to the trigger so that we can toggle whether or not Airflow should succeed the task when the sync status returns as warning. 