### PR TITLE
CEPO-1536 # send sync_id and sync_request_id to xcoms

### DIFF
--- a/airflow_provider_hightouch/triggers/hightouch.py
+++ b/airflow_provider_hightouch/triggers/hightouch.py
@@ -132,7 +132,7 @@ class HightouchTrigger(BaseTrigger):
                     or (status == WARNING and not self.error_on_warning)
                 ):
                     self.log.info(f"{self.sync_run_url} finished with status {status}!")
-                    yield TaskSuccessEvent()
+                    yield TaskSuccessEvent(xcoms={"sync_id": self.sync_id, "sync_request_id": self.sync_request_id})
                     return
 
                 elif status in PENDING_STATUSES:

--- a/airflow_provider_hightouch/triggers/hightouch.py
+++ b/airflow_provider_hightouch/triggers/hightouch.py
@@ -132,7 +132,12 @@ class HightouchTrigger(BaseTrigger):
                     or (status == WARNING and not self.error_on_warning)
                 ):
                     self.log.info(f"{self.sync_run_url} finished with status {status}!")
-                    yield TaskSuccessEvent(xcoms={"sync_id": self.sync_id, "sync_request_id": self.sync_request_id})
+                    yield TaskSuccessEvent(
+                        xcoms={
+                            "sync_id": self.sync_id,
+                            "sync_run_id": self.sync_request_id
+                        }
+                    )
                     return
 
                 elif status in PENDING_STATUSES:


### PR DESCRIPTION
This PR enables pushing sync_id and sync_run_id to XComs upon sync completion. By passing these values to downstream Snowflake queries, we can filter out and ignore errors that are known issues and occur regularly during the sync process. This allows us to focus on new or unexpected errors, improving the accuracy and relevance of our error monitoring.