### PR TITLE
CEPO-1990 # pass session to run function

### DIFF
--- a/airflow_provider_hightouch/hooks/hightouch.py
+++ b/airflow_provider_hightouch/hooks/hightouch.py
@@ -1,4 +1,5 @@
 import datetime
+import aiohttp
 import asyncio
 import time
 from typing import Any, Dict, List, Optional
@@ -339,6 +340,7 @@ class HightouchAsyncHook(HttpAsyncHook):
             try:
                 self.method = method
                 response = await self.run(
+                    session=aiohttp.ClientSession(),
                     endpoint=urljoin(self.api_base_url, endpoint),
                     data=data,
                     headers=headers,

--- a/airflow_provider_hightouch/hooks/hightouch.py
+++ b/airflow_provider_hightouch/hooks/hightouch.py
@@ -339,13 +339,14 @@ class HightouchAsyncHook(HttpAsyncHook):
         while True:
             try:
                 self.method = method
-                response = await self.run(
-                    session=aiohttp.ClientSession(),
-                    endpoint=urljoin(self.api_base_url, endpoint),
-                    data=data,
-                    headers=headers,
-                )
-                resp_dict = await response.json()
+                async with aiohttp.ClientSession() as session:
+                    response = await self.run(
+                        session=session,
+                        endpoint=urljoin(self.api_base_url, endpoint),
+                        data=data,
+                        headers=headers,
+                    )
+                    resp_dict = await response.json()
                 return resp_dict["data"] if "data" in resp_dict else resp_dict
             except AirflowException as e:
                 self.log.error("Request to Hightouch API failed: %s", e)


### PR DESCRIPTION
The run()'s required parameters have changed and it now requires an explicit session argument. While this was previously handled within the upstream HTTP hook, a recent update to the provider mandates that we pass the session directly. 