### PR TITLE
Use providers common compat SDK and update deps

### DIFF
--- a/airflow_provider_hightouch/example_dags/example_hightouch_trigger_sync.py
+++ b/airflow_provider_hightouch/example_dags/example_hightouch_trigger_sync.py
@@ -1,7 +1,7 @@
 import datetime
 
 from airflow.providers.standard.operators.latest_only import LatestOnlyOperator
-from airflow.sdk import DAG
+from airflow.providers.common.compat.sdk import DAG
 
 from airflow_provider_hightouch.operators.hightouch import HightouchTriggerSyncOperator
 from airflow_provider_hightouch.sensors.hightouch import HightouchSyncRunSensor

--- a/airflow_provider_hightouch/operators/hightouch.py
+++ b/airflow_provider_hightouch/operators/hightouch.py
@@ -1,8 +1,6 @@
 from typing import Optional, Sequence
 
-from airflow.exceptions import AirflowException
-from airflow.models.taskinstancekey import TaskInstanceKey
-from airflow.sdk import BaseOperator, BaseOperatorLink
+from airflow.providers.common.compat.sdk import AirflowException, BaseOperator, BaseOperatorLink, TaskInstanceKey
 
 from airflow_provider_hightouch.hooks.hightouch import HightouchHook
 from airflow_provider_hightouch.utils import parse_sync_run_details

--- a/airflow_provider_hightouch/sensors/hightouch.py
+++ b/airflow_provider_hightouch/sensors/hightouch.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
-from airflow.exceptions import AirflowException
-from airflow.sdk import BaseSensorOperator
+from airflow.providers.common.compat.sdk import AirflowException, BaseSensorOperator
 
 from airflow_provider_hightouch.consts import (
     PENDING_STATUSES,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,9 @@ classifiers = [
 ]
 dependencies = [
     "requests",
-    "apache-airflow>=3.0.0",
-    "apache-airflow-providers-http>=6.0.0",
+    "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.14.0",
+    "apache-airflow-providers-http>=4.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
The upstream Hightouch provider (v5.0.0) dropped Airflow 2 support by importing directly from airflow.sdk, which only exists in Airflow 3. Since we're still running Airflow 2 but preparing for the Airflow 3 migration, this PR updates our fork to use airflow.providers.common.compat.sdk, the official Apache compatibility layer that routes imports to the correct paths on both Airflow 2 and 3.

<img width="880" height="305" alt="image" src="https://github.com/user-attachments/assets/75561665-0748-4f2e-a2bb-64ec124fc911" />